### PR TITLE
language-selection: adding language state and update function

### DIFF
--- a/views/demo.jsx
+++ b/views/demo.jsx
@@ -47,6 +47,7 @@ const Demo = React.createClass({
       newUtteranceAvatarType: initialLastUtterance.user.type === 'agent' ? 'customer_avatar' : 'agent_avatar', // 'customer_avatar'
       showJson: false,
       isResetting: false,
+      language: 'en',
       loading: false,
       initializing: true,
     };
@@ -167,6 +168,12 @@ const Demo = React.createClass({
       this.setState({
         error,
       });
+    });
+  },
+
+  updateLanguage(language) {
+    this.setState({
+      language,
     });
   },
 
@@ -308,8 +315,9 @@ const Demo = React.createClass({
           </div>) :
           (<div>
             <LanguageSelector
-              lang="en"
+              onLanguageSelection={this.updateLanguage}
             />
+            <div>selected language is {this.state.language}</div>
             <Output
               conversation={this.state.conversation.utterances}
               onVote={this.onVote}

--- a/views/language-selector.jsx
+++ b/views/language-selector.jsx
@@ -5,39 +5,20 @@ const LanguageSelector = React.createClass({
 
   displayName: 'LanguageSelector',
 
-  getInitialState() {
-    return {
-      lang: 'en',
-    };
-  },
-
-  updateLanguage(e) {
-    if (e.target.id.toString() === 'en') {
-      this.setState({
-        lang: 'en',
-      });
-    } else {
-      this.setState({
-        lang: 'fr',
-      });
-    }
+  propTypes: {
+    onLanguageSelection: React.PropTypes.func.isRequired,
   },
 
   render() {
     return (
       <div className="language_selection_container">
         <div className="select_language_header">Select Language: </div>
-
-        {/* Generate a div for each utterance in the conversation object */}
         <div className="language_options">
           {
             <ButtonsGroup
               type="radio"
               name="radio-buttons"
-              // eslint-disable-next-line no-console
-              onClick={e => this.updateLanguage(e)}
-              // eslint-disable-next-line no-console
-              onChange={e => console.log('Language changed to ', e.target.value)}
+              onClick={e => this.props.onLanguageSelection(e.target.id)}
               buttons={[{
                 value: 1,
                 id: 'en',


### PR DESCRIPTION
Lifting `language` state var and `updateLanguage` function up to `demo.jsx`.  You can now use that state in `demo.jsx` or any of its child components (passing it in as a prop).
Using `language` state in a `div` in `demo.jsx`.
Passing `updateLanguage` function to `language-selector.jsx` as a prop.
Note: `language-selector.jsx` is a stateless functional component so could be rewritten.  Alternatively, could add the `ButtonGroup` directly to `demo.jsx` as there isn't more to it than the `ButtonGroup`